### PR TITLE
Fix magic healing effect

### DIFF
--- a/common/scripted_effects/wh_scripted_effects.txt
+++ b/common/scripted_effects/wh_scripted_effects.txt
@@ -6732,29 +6732,20 @@ heal_effect = {
 		}
 		random_list = {
 			4 = {
-				damage_unit = {
-					amount = -5
-				}
+                troops = -0.005
 			}
 			2 = {
-				damage_unit = {
-					amount = -10
-				}
+                troops = -0.010
 			}
 			1 = {
-				damage_unit = {
-					amount = -15
-				}
+                troops = -0.015
 			}
 			1 = {
-				damage_unit = {
-					amount = -20
-				}
+                troops = -0.020
 			}
 			1 = {
-				damage_unit = {
-					amount = -25
-				}
+                troops = -0.025
+
 			}
 		}
 	}

--- a/common/scripted_effects/wh_scripted_effects.txt
+++ b/common/scripted_effects/wh_scripted_effects.txt
@@ -6732,19 +6732,19 @@ heal_effect = {
 		}
 		random_list = {
 			4 = {
-                troops = -0.005
+                troops = 0.005
 			}
 			2 = {
-                troops = -0.010
+                troops = 0.010
 			}
 			1 = {
-                troops = -0.015
+                troops = 0.015
 			}
 			1 = {
-                troops = -0.020
+                troops = 0.020
 			}
 			1 = {
-                troops = -0.025
+                troops = 0.025
 
 			}
 		}
@@ -6771,19 +6771,19 @@ morale_heal_effect = {
 			1 = {
 			}
 			4 = {
-				damage_unit_morale = -0.01
+				morale = 0.01
 			}
 			2 = {
-				damage_unit_morale = -0.02
+				morale = 0.02
 			}
 			1 = {
-				damage_unit_morale = -0.03
+				morale = 0.03
 			}
 			1 = {
-				damage_unit_morale = -0.04
+				morale = 0.04
 			}
 			1 = {
-				damage_unit_morale = -0.06
+				morale = 0.06
 			}
 		}
 	}


### PR DESCRIPTION
Currently healing spells don't work because **damage_unit** and **damage_unit_morale** doesn't allow negative numbers.  This fixes the problem by using **troops** and **morale** keywords.