### PR TITLE
fix to reduce AI magic spamming and allow casting out-of-combat

### DIFF
--- a/common/static_modifiers.txt
+++ b/common/static_modifiers.txt
@@ -1087,7 +1087,7 @@ elven_culture_modifier = {
     light_infantry_defensive = 0.5 
 	light_infantry_offensive = 1.0
 	heavy_infantry_defensive = 0.5
-    heavy_infantry_defensive = 1.0
+    heavy_infantry_offensive = 1.0
     land_organisation = 0.5
     land_morale = 0.8
 }

--- a/decisions/wh_magic_decisions.txt
+++ b/decisions/wh_magic_decisions.txt
@@ -1361,6 +1361,9 @@ targetted_decisions = {
 			}
 			or = {
 				ai = no
+				liege = {
+					ai = no
+				}                
 				in_battle = yes
 				in_siege = yes
 			}

--- a/decisions/wh_magic_decisions.txt
+++ b/decisions/wh_magic_decisions.txt
@@ -1353,19 +1353,11 @@ targetted_decisions = {
 			age = 16
 			z_combat_magic_caster = yes
 			z_combat_magic_valid_caster = yes
-			OR = {
+			or = {
 				character = FROM
 				liege = {
 					character = FROM
 				}
-			}
-			or = {
-				ai = no
-				liege = {
-					ai = no
-				}                
-				in_battle = yes
-				in_siege = yes
 			}
 		}
 		allow = {
@@ -1381,6 +1373,18 @@ targetted_decisions = {
 			}
 			in_command = yes
 		}
+
+		ai_will_do = {
+			factor = 0.025
+			modifier = {
+				factor = 10
+				or = {
+					in_battle = yes
+                    in_siege = yes
+                    }
+			}
+		}
+
 		effect = {
 			set_character_flag = casting
 			save_event_target_as = magic_caster


### PR DESCRIPTION
What the title says.  A quick and easy fix for now.

A proper solution would actually make the AI use magic strategically (e.g. more siege spells in sieges), but that would take a lot longer to do and probably people won't even notice much.

Also an unrelated typo fix.