### PR TITLE
spell "Sacred Light of Fertility" (High Magic) fix

### DIFF
--- a/events/wh_magic_lore_high_magic.txt
+++ b/events/wh_magic_lore_high_magic.txt
@@ -565,8 +565,8 @@ character_event = {
 }
 
 character_event = {
-	id = high_magic_lore_non_battle.401# Apotheosis 1"
-	desc = high_magic_lore_non_battle.401_desc# "Your spell restores those close to death or those freshly dead"
+	id = high_magic_lore_non_battle.401# "Sacred Light of Fertility"
+	desc = high_magic_lore_non_battle.401_desc# "Empower the fertility of the target character's lands. This spell will boost the prosperity in a random province."
 	is_triggered_only = yes
 	picture = GFX_evt_mage_lore_high_magic
 
@@ -575,12 +575,12 @@ character_event = {
 	}
 
 	option = {
-		name = high_magic_lore_non_battle.401a# Cast Another Spell ?
+		name = high_magic_lore_non_battle.401a# "OK" button with spell effect info
 		character_event = {
 			id = z_spell_menu.99998
 		}
 		event_target:spelltarget = {
-			any_demesne_province = {
+			random_demesne_province = {
 				limit = {
 					NOT = {
 						has_province_modifier = prosperity_modifier_3


### PR DESCRIPTION
1) This spell boost prosperity in all player's provinces, not in random.
So, according to description need to use random_demesne_province, not any_demesne_province.
2) Change wrong spell name and description to correct.