### PR TITLE
building Darkrider Stables (Druchii tribal settelment) fix and spell "Taming of the Wilds" (Lore of Beasts) fix

### DIFF
--- a/common/buildings/wh_druchii.txt
+++ b/common/buildings/wh_druchii.txt
@@ -4455,6 +4455,9 @@ tribal = {
 	# Darkriders
 	tb_darkriders_1 = {
 		desc = ca_druchiidarkriders_1_desc
+		not_if_x_exists = {
+			tb_coldonestable_1 tb_coldonestable_2 tb_coldonestable_3 tb_coldonestable_4
+		}
 		trigger = {
 			TECH_CAVALRY = 0
 		}
@@ -4468,6 +4471,14 @@ tribal = {
 			}
 			ROOT = {
 				culture_group = druchi_group
+			}
+			FROMFROM = {
+				NOR = {
+					has_building = tb_coldonestable_1
+					has_building = tb_coldonestable_2
+					has_building = tb_coldonestable_3
+					has_building = tb_coldonestable_4
+				}
 			}
 		}
 		extra_tech_building_start = 1

--- a/events/wh_magic_lore_beasts.txt
+++ b/events/wh_magic_lore_beasts.txt
@@ -848,8 +848,8 @@ character_event = {
 }
 
 character_event = {
-	id = beasts_lore_non_battle.301# Apotheosis 1"
-	desc = beasts_lore_non_battle.301_desc# "Your spell restores those close to death or those freshly dead"
+	id = beasts_lore_non_battle.301# "Taming of the Wilds"
+	desc = beasts_lore_non_battle.301_desc# "A Mighty Beast is called from the wilds to serve as the noble to steed to [spelltarget.GetBestName]. For the denizens of deepest lustria, the mighty dinosaurs ramble and roar in their noble service."
 	is_triggered_only = yes
 	picture = GFX_evt_mage_lore_beasts
 
@@ -858,7 +858,7 @@ character_event = {
 	}
 
 	option = {
-		name = beasts_lore_non_battle.301a# Cast Another Spell ?
+		name = beasts_lore_non_battle.301a# "OK" button with spell effect info
 		trigger = {
 			event_target:spelltarget = {
 				culture_group = lizardman_group
@@ -915,16 +915,18 @@ character_event = {
 	}
 
 	option = {
-		name = beasts_lore_non_battle.301b# Cast Another Spell ?
+		name = beasts_lore_non_battle.301b# "OK" button with spell effect info
 		trigger = {
 			event_target:spelltarget = {
 				not = {
 					graphical_culture = lizardmangfx
 				}
+				nor = {
 				has_artifact = pegasus_mount
 				has_artifact = nightmare_mount
 				has_artifact = red_dragon_mount
 				has_artifact = gryphon_mount
+				}
 			}
 		}
 		event_target:spelltarget = {


### PR DESCRIPTION
1) Darkrider Stables and Cold One Stables are mutually exclusive buildings, so need not_if_x_exists = { } (don't allow to build) and FROMFROM = { } (hide building from list) in both building.
2) This spell must be allowed to cast only, if spellcaster hasn't such mounts, and not vice versa (like for lizardmen's mounts).