### PR TITLE
tb_autslavemarket_3 building fix

### DIFF
--- a/common/buildings/wh_druchii.txt
+++ b/common/buildings/wh_druchii.txt
@@ -4715,7 +4715,7 @@ tribal = {
 		trigger = {
 			TECH_CITY_CONSTRUCTION = 4
 		}
-		upgrades_from = tb_market_town_2
+		upgrades_from = tb_autslavemarket_2
 		potential = {
 			FROM = {
 				culture_group = druchi_group


### PR DESCRIPTION
Неправильное условие апгрейда "культурно-уникального" рынка блокировало постройку 3-го и 4-го уровня дефолтного рынка во всех племенных поселениях.