### PR TITLE
ca_norscan_shipyard_4 fix

### DIFF
--- a/common/buildings/wh_norscan.txt
+++ b/common/buildings/wh_norscan.txt
@@ -842,7 +842,7 @@ castle = {
 			culture_group = norscan_group
 		}
 		replaces = ca_shipyard_4
-		upgrades_from = ca_shipyard_3
+		upgrades_from = ca_norscan_shipyard_3
 		gold_cost = 100
 		build_time = 1460
 		galleys =16


### PR DESCRIPTION
Неправильное условие не позволяло строить в замках 4й уровень верфи.