### PR TITLE
tb_coldonestable_4 building fix

### DIFF
--- a/common/buildings/wh_druchii.txt
+++ b/common/buildings/wh_druchii.txt
@@ -4351,7 +4351,7 @@ tribal = {
 				}
 			}
 		}
-		convert_to_castle = ca_druchiicoldones_1
+		convert_to_castle = ca_druchiicoldones_2
 		extra_tech_building_start = 2.5
 	}
 


### PR DESCRIPTION
При изменении племенного поселения в замок должно изменяться на 2-й уровень и как и все прочие племенные постройки.