### PR TITLE
Burning of the Erengrad Veche event fix

### DIFF
--- a/common/on_actions/wh_on_actions.txt
+++ b/common/on_actions/wh_on_actions.txt
@@ -597,6 +597,8 @@ on_new_holder_inheritance = {
 		svampires.81 #Shadowrealm collapses
 		DR_misc.1001 #Special title localisations ( Elector-Counts, Everqueen )
 		asur.53002 #Destroy Supercourtier titles
+		# Burning of the Erengrad Veche
+		erengrad.101
 	}
 }
 
@@ -611,6 +613,8 @@ on_new_holder_usurpation = {
 		aicleanup.029 # Destroy Samur's Witch Hunter Chapter
 		DR_misc.1001 #Special title localisations ( Elector-Counts, Everqueen )
 		asur.53002 #Destroy Supercourtier titles
+		# Burning of the Erengrad Veche
+		erengrad.101
 	}
 }
 


### PR DESCRIPTION
После победы в войне ивент не срабатывал, так как за это отвечает триггер on_new_holder_usurpation.
Так же добавил в on_new_holder_usurpation: если ребенок унаследует данное королевство, будет возможность выбора по данному ивенту.